### PR TITLE
Rewrite lines for download / parse messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ nosetests.xml
 # Geoip stuff
 GeoIPCity.dat
 GeoLiteCity.dat.gz
+
+# Web
+web/data.json

--- a/geoip.py
+++ b/geoip.py
@@ -28,7 +28,9 @@ class DownloadThread(threading.Thread):
         while True:
             buffer = u.read(block_sz)
             if not buffer:
+                sys.stdout.write("\n")
                 break
+
             file_size_dl += len(buffer)
             f.write(buffer)
 
@@ -41,7 +43,10 @@ class DownloadThread(threading.Thread):
                 status = "%.1f%% [%s%s]" % (percentage, "=" * characters, " " * deficit)
 
                 last_perc = percentage
-                print status
+
+                # Print with \r (carriage return) to overwrite previous line
+                sys.stdout.write("%s\r" % status)
+                sys.stdout.flush()
 
         print("GeoIP file downloaded, extracting.")
         f.close()
@@ -107,8 +112,14 @@ def main():
         done += 1
         percentage = done * 100. / total
         if percentage - last_perc > 5:
-            print(("%.1f" % percentage) + "% IPs processed")
+            status = ("%.1f" % percentage) + "% IPs processed"
+
+            sys.stdout.write("%s\r" % status)
+            sys.stdout.flush()
+
             last_perc = percentage
+
+    sys.stdout.write("\n")
 
     with open('web/data.json', 'w+') as dataFile:
         dataFile.write("var data = ")


### PR DESCRIPTION
This commit changes the previous behavior in the
application to write out a sequence of lines for
every single new download / process progress
margin. The new behavior writes the progress,
then the next behavior overwrites the previous
message, ultimately only leaving a "100%" message.

Here is an example. Previously:

```
Downloading: GeoLiteCity.dat.gz Bytes: 11896864
0.1% [                                   ]
1.0% [                                   ]
2.0% [                                   ]
```

Now:

```
Downloading: GeoLiteCity.dat.gz Bytes: 11896864
3.4% [=                                  ]
```

This is also changed for the "Processing IPs"
message. I also added the `web/data.json` file
to the `.gitignore`.
